### PR TITLE
NCIPPE-364 | Remove 'view account' link from CRC system notifications generated when a participant is added from OPEN

### DIFF
--- a/src/main/resources/NotificationService.properties
+++ b/src/main/resources/NotificationService.properties
@@ -26,9 +26,9 @@ patient.receives.invitation.from=PPE system generated email
 patient.receives.invitation.message=<p>%{FullName}\u2019s information is now available in your account.</p><p><a data-route="true" href="/dashboard/participant/%{PatientId}">View account</a></p>
 
 ## Notify CRC when a new patient record from OPEN is inserted into PPE DB
-patient.added.from.open.title=A new participant has been added to the Biobank
+patient.added.from.open.title=A new participant has joined the Biobank
 patient.added.from.open.from=PPE system generated email
-patient.added.from.open.message=Please update their personal information and upload a consent form.</p><p><a data-route="true" href="/dashboard/participant/%{PatientId}">View account</a></p>
+patient.added.from.open.message=A new participant has joined the Biobank. Please select their Participant ID from your participant list to update their name and email address and upload a consent form.
 
 ## Notify patient when their provider changes.
 provider.change.for.patient.title=Your healthcare provider has changed


### PR DESCRIPTION
1. Modified the message as per new requirement